### PR TITLE
Removes allowed_format module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     ],
     "require": {
         "drupal/access_unpublished": "^1.5",
-        "drupal/allowed_formats": "^3.0",
         "drupal/editor_advanced_link": "^2.0",
         "drupal/linkit": "^6.1",
         "drupal/nomarkup": "^1.0",

--- a/recipe.yml
+++ b/recipe.yml
@@ -10,7 +10,6 @@ install:
   - tour
   # Contrib.
   - access_unpublished
-  - allowed_formats
   - editor_advanced_link
   - linkit
   - nomarkup


### PR DESCRIPTION
## Description

From Carlos:

I think we can remove "allowed_formats" from: https://github.com/kanopi/saplings-editorial/blob/main/composer.json - version 3.0.0 is just a way to migrate to the now in core field settings https://www.drupal.org/project/allowed_formats. See: https://www.drupal.org/node/3318572

Unless we are using it for this:

The module provides also a feature that allows site builders to hide the formatted text format help and guidelines. Even this feature is still preserved in the 3.0.x module branch, there is an issue that aims to move it in Drupal core in the future. See https://www.drupal.org/i/3323007.

## Related Ticket 
https://kanopi.teamwork.com/app/tasks/29488454

## Deploy Notes
https://github.com/kanopi/saplings-editorial/pull/6